### PR TITLE
Manage constraint exceptions that relate to directory creation.

### DIFF
--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -281,13 +281,32 @@ class MediaSourceService {
       }
 
       $directory = $this->fileSystem->dirname($content_location);
-      if (!$this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
-        throw new HttpException(500, "The destination directory does not exist, could not be created, or is not writable");
+      try {
+        if (!$this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
+          throw new HttpException(500, "The destination directory does not exist, could not be created, or is not writable");
+        }
+      } catch (\Drupal\Core\Database\IntegrityConstraintViolationException $constraintEx) {
+        // ignore
+      } catch (\Exception $e) {
+        throw new HttpException(500, sprintf("%s %s", get_class($e), $e->getMessage()), $e);
       }
 
       // Copy over the file content.
-      $this->updateFile($file, $resource, $mimetype);
-      $file->save();
+      try {
+        $this->updateFile($file, $resource, $mimetype);
+      } catch (\Drupal\Core\Database\IntegrityConstraintViolationException $constraintEx) {
+        if (!str_contains($constraintEx->getMessage(), sprintf("'%s'", $directory))) {
+          throw new HttpException(500, sprintf("Constraint violation when updating file: %s", $constraintEx->getMessage()), $constraintEx);
+        }
+      } catch (\Exception $e) {
+        throw new HttpException(500, sprintf("Error updating file: %s", $e->getMessage()), $e);
+      }
+
+      try {
+        $file->save();
+      } catch (EntityStorageException $e) {
+        throw new HttpException(500, sprintf("Error saving file: %s", $e->getMessage()), $e);
+      }
 
       // Construct the Media.
       $media_struct = [
@@ -312,7 +331,11 @@ class MediaSourceService {
       }
 
       $media = $this->entityTypeManager->getStorage('media')->create($media_struct);
-      $media->save();
+      try {
+        $media->save();
+      } catch (EntityStorageException $e) {
+        throw new HttpException(500, sprintf("Error saving media: %s", $e->getMessage()), $e);
+      }
       return $media;
     }
 


### PR DESCRIPTION
`MediaSourceController` and its service `MediaSourceService` do not handle concurrent requests robustly.  

One issue is that multiple requests may result in interleaved transactions, and as a result, the loosing transaction will abort with a constraint violation.

This patch isolates a common constraint violation: two simultaneous requests attempting to create the same directory (typically based on the current year and date).  Primary key constraint violations that apply to the same directory name will be ignored.

Additionally, interactions with file and entity subsystems are surrounded by try/catch blocks so if they occur, they are more readily identified in logs.